### PR TITLE
Benchmark actions

### DIFF
--- a/app/src/main/java/com/github/raulccabreu/redukt/Redukt.kt
+++ b/app/src/main/java/com/github/raulccabreu/redukt/Redukt.kt
@@ -32,6 +32,8 @@ class Redukt<T>(state: T) {
 
     private fun reduce(action: Action<*>) {
         val elapsed = measureTimeMillis {
+            val listeners = listeners.toSet() //to avoid concurrent modification exception
+            val middlewares = middlewares.toSet()
             val oldState = state
             var tempState = state
             middlewares.parallelFor { it.before(tempState, action) }

--- a/app/src/main/java/com/github/raulccabreu/redukt/Redukt.kt
+++ b/app/src/main/java/com/github/raulccabreu/redukt/Redukt.kt
@@ -4,6 +4,7 @@ import com.github.raulccabreu.redukt.actions.Action
 import com.github.raulccabreu.redukt.middlewares.Middleware
 import com.github.raulccabreu.redukt.reducers.Reducer
 import com.github.raulccabreu.redukt.states.StateListener
+import kotlin.system.measureTimeMillis
 
 class Redukt<T>(state: T) {
     var state = state
@@ -11,6 +12,7 @@ class Redukt<T>(state: T) {
     val reducers = mutableSetOf<Reducer<T>>()
     val middlewares = mutableSetOf<Middleware<T>>()
     val listeners = mutableSetOf<StateListener<T>>()
+    var traceActionProfile = false
     private val dispatcher = Dispatcher { reduce(it) }
 
     init { start() }
@@ -29,16 +31,19 @@ class Redukt<T>(state: T) {
     }
 
     private fun reduce(action: Action<*>) {
-        val oldState = state
-        var tempState = state
-        middlewares.parallelFor { it.before(tempState, action) }
-        reducers.forEach { tempState = it.reduce(tempState, action) }
-        state = tempState
-        listeners.parallelFor { notifyReducer(it, oldState) }
-        middlewares.parallelFor { it.after(tempState, action) }
+        val elapsed = measureTimeMillis {
+            val oldState = state
+            var tempState = state
+            middlewares.parallelFor { it.before(tempState, action) }
+            reducers.forEach { tempState = it.reduce(tempState, action) }
+            state = tempState
+            listeners.parallelFor { notifyListeners(it, oldState) }
+            middlewares.parallelFor { it.after(tempState, action) }
+        }
+        if (traceActionProfile) println("[Redukt] [$elapsed ms] Action ${action.name}")
     }
 
-    private fun notifyReducer(it: StateListener<T>, oldState: T) {
+    private fun notifyListeners(it: StateListener<T>, oldState: T) {
         if (it.hasChanged(state, oldState)) it.onChanged(state)
     }
 }


### PR DESCRIPTION
Add a feature to make easy to measure the time spent for every action that goes through redukt. This is very useful to detect easily the bottlenecks. 

To enable the benchmark just set trace `true`

        redukt.traceActionProfile = true


This PR also solves a problem when new listeners are added during the dispatch, which raises a concurrent modification exception.

### Benchmark sample

```java
I/System.out( 3204): [Redukt] [537 ms] Action SYNC_SCOPES
I/System.out( 3204): [Redukt] [913 ms] Action REQUEST_POLLING
I/System.out( 3204): [Redukt] [630 ms] Action ASYNC_STARTED
I/System.out( 3204): [Redukt] [571 ms] Action RECEIVED_ESTIMATE_SERVICES
I/System.out( 3204): [Redukt] [424 ms] Action REMOVE_INACTIVE_ESTIMATE_SERVICES
I/System.out( 3204): [Redukt] [549 ms] Action RECEIVED_EAV_TEMPLATES
I/System.out( 3204): [Redukt] [455 ms] Action REMOVE_INACTIVE_EAV_TEMPLATES
I/System.out( 3204): [Redukt] [1494 ms] Action ASYNC_COMPLETED
I/System.out( 3204): [Redukt] [451 ms] Action SAVE_APP_STATE
```